### PR TITLE
Adjust pen down to S35 so that it is put down gently in the real plotter

### DIFF
--- a/DrawGcode.py
+++ b/DrawGcode.py
@@ -91,7 +91,7 @@ def file_reader(filename):
         elif "M280" in line:
             if "P0" in line and "S" in line:
                 s = readKey(line, "S")
-                if s >= 40:
+                if s >= 35:
                     pen = True
                 elif s == 0:
                     pen = False

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A simple program that allows the graphical preview of .gcode files by utilising 
 Mainly written for internal use in teaching the workings of G-code.
 
 Since it is written for use with a plotter only 2D G-codes are supported. The pen is controlled via M280 P0 S? commands
-S>40 is interpreted as pen down, S=0 is interpreted as pen up.
+S>35 is interpreted as pen down, S=0 is interpreted as pen up.
 
 Supported commands:
 G28


### PR DESCRIPTION
We've switched the pen in the real plotter to a fineliner. To protect the pen we didn't want it to be slammed onto the paper. This position of the swivel is just enough to let it draw on the paper.